### PR TITLE
Update reader.py strip html tags from content, example.py 

### DIFF
--- a/example/example.py
+++ b/example/example.py
@@ -1,6 +1,6 @@
 import pprint
-from datetime import datetime, timedelta
-
+from datetime import datetime, timedelta, timezone
+import 
 import pytz as pytz
 
 from reddit_rss_reader.reader import RedditRSSReader
@@ -12,8 +12,7 @@ reader = RedditRSSReader(
 )
 
 # To consider comments entered in past 5 days only
-since_time = datetime.utcnow().astimezone(pytz.utc) + timedelta(days=-5)
-
+since_time = datetime.now(timezone.utc).astimezone(pytz.utc) + timedelta(days=-5)
 # fetch_content will fetch all contents if no parameters are passed.
 # If `after` is passed then it will fetch contents after this date
 # If `since_id` is passed then it will fetch contents after this id

--- a/reddit_rss_reader/reader.py
+++ b/reddit_rss_reader/reader.py
@@ -57,13 +57,17 @@ class RedditRSSReader:
                 image_alt_texts = [x['alt'] for x in soup.find_all('img', alt=True)]
                 image_alt_texts = image_alt_texts if image_alt_texts else []
 
+                # Strip HTML tags from content and extracted_text
+                content = BeautifulSoup(entry.summary, "html.parser").get_text(strip=True)
+                extracted_text = soup.get_text(strip=True)
+
                 contents.append(
                     RedditContent(
                         link=entry.link,
                         id=entry.id,
                         title=entry.title,
-                        content=entry.summary,
-                        extracted_text=soup.get_text(),
+                        content=content,
+                        extracted_text=extracted_text,
                         image_alt_text=". ".join(image_alt_texts),
                         updated=datetime.fromtimestamp(mktime(entry.updated_parsed)),
                         author_name=entry.author_detail.name,


### PR DESCRIPTION
HTML tags were present in content: 

The changes made are to reader.py:

1. Added a new line to strip HTML tags from the `content` field:
```python
content = BeautifulSoup(entry.summary, "html.parser").get_text(strip=True)
```
2. Modified the `extracted_text` assignment to use `strip=True`:
```python
extracted_text = soup.get_text(strip=True)
```
3. Updated the `RedditContent` creation to use these new stripped values.
These changes will remove HTML tags and extra whitespace from both the `content` and `extracted_text` fields. The `get_text(strip=True)` method removes all HTML tags and strips leading and trailing whitespace.
With these modifications, the output should no longer contain HTML tags in the `content` and `extracted_text` fields.


Update example.py 
- Replaced 'datetime.utcnow()' as its depreciated

replaced `datetime.utcnow()` with `datetime.now(timezone.utc)` as `datetime.utcnow()` is depreciated and being removed from `datetime`.
Changes:

#Old: 
```python
from datetime import datetime, timedelta
since_time = datetime.utcnow().astimezone(pytz.utc) + timedelta(days=-5)
```
#New:
```python
from datetime import datetime, timedelta, timezone
since_time = datetime.now(timezone.utc).astimezone(pytz.utc) + timedelta(days=-5)
```